### PR TITLE
fix: remove unnecessary API call to fetch account data

### DIFF
--- a/public/partials/simple-photo-feed-public-display.php
+++ b/public/partials/simple-photo-feed-public-display.php
@@ -18,7 +18,6 @@ $size     = $atts['size'];
 $lightbox = $atts['lightbox'];
 $api      = new Simple_Photo_Feed_Api();
 $media    = $api->spf_get_media();
-$profile  = $api->spf_get_account();
 
 if ( ! isset( $options['[auth]'] ) && ! empty( $options['token'] ) ) :
 


### PR DESCRIPTION
This PR removes the `$api->spf_get_account()` call from the frontend view. This API call was redundant in this context and was causing an unnecessary request to the Instagram API on every page load, increasing the TTFB by approximately 200ms without caching.

Thank you for your work :)